### PR TITLE
Update SDK version requirements and clean up documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Enhanced Compatibility**: Updated SDK version requirements to match flutter_inappwebview ^6.1.5
   - Dart SDK: ^3.0.6 → ^3.5.0
   - Flutter: >=3.0.0 → >=3.24.0
-- **Updated Dependencies**: Updated flutter_lints to ^6.0.0 for latest linting rules
+- **Updated Dependencies**: Kept flutter_lints at ^5.0.0 for broader SDK compatibility
 - **Documentation**: 
   - Updated README files and fixed repository URLs
   - Removed outdated build error note about isInspectable vs debuggingEnabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2025-08-08
+
+### 🔧 Improvements
+- **Enhanced Compatibility**: Updated SDK version requirements to match flutter_inappwebview ^6.1.5
+  - Dart SDK: ^3.0.6 → ^3.5.0
+  - Flutter: >=3.0.0 → >=3.24.0
+- **Updated Dependencies**: Updated flutter_lints to ^6.0.0 for latest linting rules
+- **Documentation**: 
+  - Updated README files and fixed repository URLs
+  - Removed outdated build error note about isInspectable vs debuggingEnabled
+- **Licensing**: Added proper MIT License file
+
 ## [0.1.0] - 2025-08-08
 
 ### 🎉 Initial Release

--- a/README.md
+++ b/README.md
@@ -497,7 +497,6 @@ MaterialApp(
 
 1. **"No Overlay widget found"**: Move the inspector widget from MaterialApp.builder to inside a Scaffold Stack
 2. **Inspector not showing**: Ensure you've called `InAppWebViewInspector.enable()` after registering a WebView
-3. **Build errors**: Make sure to use `isInspectable: true` instead of deprecated `debuggingEnabled`
 
 ### Development vs Production
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -348,7 +348,6 @@ MaterialApp(
 
 1. **"No Overlay widget found"**: インスペクターウィジェットをMaterialApp.builderからScaffold Stack内に移動
 2. **インスペクターが表示されない**: WebView登録後に`InAppWebViewInspector.enable()`が呼び出されていることを確認
-3. **ビルドエラー**: 非推奨の`debuggingEnabled`の代わりに`isInspectable: true`を使用していることを確認
 
 ## 📋 要件
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -348,7 +348,6 @@ MaterialApp(
 
 1. **"No Overlay widget found"**: 검사기 위젯을 MaterialApp.builder에서 Scaffold Stack 내부로 이동
 2. **검사기가 표시되지 않음**: WebView를 등록한 후 `InAppWebViewInspector.enable()`이 호출되었는지 확인
-3. **빌드 오류**: 더 이상 사용되지 않는 `debuggingEnabled` 대신 `isInspectable: true`를 사용하는지 확인
 
 ## 📋 요구사항
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^6.0.0
+  flutter_lints: ^5.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,23 +1,23 @@
 name: inappwebview_inspector
 description: "A powerful WebView inspector and debugging tool for flutter_inappwebview. Provides real-time console monitoring, JavaScript execution, and script history management with a draggable overlay interface."
-version: 0.1.0
-homepage: https://github.com/your-username/inappwebview_inspector
-repository: https://github.com/your-username/inappwebview_inspector
-issue_tracker: https://github.com/your-username/inappwebview_inspector/issues
+version: 0.1.1
+homepage: https://github.com/baccusf/inappwebview_inspector
+repository: https://github.com/baccusf/inappwebview_inspector
+issue_tracker: https://github.com/baccusff/inappwebview_inspector/issues
 
 environment:
-  sdk: ^3.0.6
-  flutter: ">=3.0.0"
+  sdk: ^3.5.0
+  flutter: ">=3.24.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  flutter_inappwebview: ^6.0.0
+  flutter_inappwebview: ^6.1.5
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
## Summary
Updates SDK version requirements to match flutter_inappwebview ^6.1.5 dependency and removes outdated documentation references.

### Changes Made
- **SDK Version Updates**:
  - Dart SDK: ^3.0.6 → ^3.5.0 (to match flutter_inappwebview 6.1.5)
  - Flutter: >=3.0.0 → >=3.24.0 (to match flutter_inappwebview 6.1.5)
  - Keep flutter_lints at ^5.0.0 for broader SDK compatibility

- **Documentation Cleanup**:
  - Remove outdated `debuggingEnabled` vs `isInspectable` note from all README files
  - Clean up English (README.md), Korean (README_ko.md), and Japanese (README_ja.md) versions
  - Update CHANGELOG.md with v0.1.1 improvements

### Benefits
- ✅ Better compatibility with flutter_inappwebview dependency
- ✅ Consistent SDK version requirements
- ✅ Clean, up-to-date documentation
- ✅ Reduced version conflicts when integrating with other packages

### Files Changed
- `pubspec.yaml` - SDK versions updated
- `README.md` - Remove outdated build error note
- `README_ko.md` - Remove outdated build error note (Korean)
- `README_ja.md` - Remove outdated build error note (Japanese)
- `CHANGELOG.md` - Document v0.1.1 changes

## Test plan
- [x] Package validation with `flutter packages pub publish --dry-run` passes
- [x] All documentation files updated consistently
- [x] SDK version requirements aligned with dependencies
- [x] No breaking changes to existing functionality

## Related Issue
Closes #1

🤖 Generated with [Claude Code](https://claude.ai/code)